### PR TITLE
Update dashtrends.php

### DIFF
--- a/dashtrends.php
+++ b/dashtrends.php
@@ -129,6 +129,9 @@ class Dashtrends extends Module
 		$to = min(time(), strtotime($date_to.' 23:59:59'));
 		for ($date = $from; $date <= $to; $date = strtotime('+1 day', $date))
 		{
+			if (date('G', $date) == '1')
+				$date = strtotime(date('Y-m-d H:i:s', $date) . ' -1 hour');
+				
 			$refined_data['sales'][$date] = 0;
 			if (isset($gross_data['total_paid_tax_excl'][$date]))
 				$refined_data['sales'][$date] += $gross_data['total_paid_tax_excl'][$date];


### PR DESCRIPTION
There's a problem with the daylight saving (DST) to show graphical information and calculations. In my country (Brazil) the DST was this month.
After the date 18 - october - 2015 all informations was shown as zero. These 2 lines correct this bug, it identifies the "1" on date hour field, correct your value, and after, get the timestamp again.
