### PR TITLE
Remove code related to live update (`push`)

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>dashtrends</name>
 	<displayName><![CDATA[Dashboard Trends]]></displayName>
-	<version><![CDATA[2.0.3]]></version>
+	<version><![CDATA[2.0.4]]></version>
 	<description><![CDATA[Adds a block whith the evolution of your stores main numbers along with a graphic.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[dashboard]]></tab>

--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>dashtrends</name>
 	<displayName><![CDATA[Dashboard Trends]]></displayName>
-	<version><![CDATA[2.0.4]]></version>
+	<version><![CDATA[2.1.0]]></version>
 	<description><![CDATA[Adds a block whith the evolution of your stores main numbers along with a graphic.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[dashboard]]></tab>

--- a/dashtrends.php
+++ b/dashtrends.php
@@ -40,20 +40,12 @@ class dashtrends extends Module
      */
     public $currency;
 
-    /**
-     * @var string
-     */
-    public $push_filename;
-
     public function __construct()
     {
         $this->name = 'dashtrends';
         $this->tab = 'dashboard';
-        $this->version = '2.0.3';
+        $this->version = '2.0.4';
         $this->author = 'PrestaShop';
-
-        $this->push_filename = _PS_CACHE_DIR_ . 'push/trends';
-        $this->allow_push = true;
 
         parent::__construct();
         $this->displayName = $this->trans('Dashboard Trends', [], 'Modules.Dashtrends.Admin');
@@ -67,7 +59,6 @@ class dashtrends extends Module
             && $this->registerHook('dashboardZoneTwo')
             && $this->registerHook('dashboardData')
             && $this->registerHook('actionAdminControllerSetMedia')
-            && $this->registerHook('actionOrderStatusPostUpdate')
         ;
     }
 
@@ -355,11 +346,6 @@ class dashtrends extends Module
         }
 
         return $data;
-    }
-
-    public function hookActionOrderStatusPostUpdate($params)
-    {
-        Tools::changeFileMTime($this->push_filename);
     }
 
     /**

--- a/dashtrends.php
+++ b/dashtrends.php
@@ -44,7 +44,7 @@ class dashtrends extends Module
     {
         $this->name = 'dashtrends';
         $this->tab = 'dashboard';
-        $this->version = '2.0.4';
+        $this->version = '2.1.0';
         $this->author = 'PrestaShop';
 
         parent::__construct();

--- a/upgrade/upgrade-2.0.4.php
+++ b/upgrade/upgrade-2.0.4.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Copyright since 2007 PrestaShop SA and Contributors
+ * PrestaShop is an International Registered Trademark & Property of PrestaShop SA
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to https://devdocs.prestashop.com/ for more information.
+ *
+ * @author    PrestaShop SA and Contributors <contact@prestashop.com>
+ * @copyright Since 2007 PrestaShop SA and Contributors
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_0_4($object)
+{
+    return $object->unregisterHook('actionOrderStatusPostUpdate');
+}

--- a/upgrade/upgrade-2.1.0.php
+++ b/upgrade/upgrade-2.1.0.php
@@ -27,7 +27,7 @@ if (!defined('_PS_VERSION_')) {
     exit;
 }
 
-function upgrade_module_2_0_4($object)
+function upgrade_module_2_1_0($object)
 {
     return $object->unregisterHook('actionOrderStatusPostUpdate');
 }

--- a/views/templates/hook/dashboard_zone_two.tpl
+++ b/views/templates/hook/dashboard_zone_two.tpl
@@ -29,7 +29,7 @@
 	var priceDisplayPrecision = {$_PS_PRICE_DISPLAY_PRECISION_|intval};
 </script>
 <div class="clearfix"></div>
-<section id="dashtrends" class="panel widget{if $allow_push} allow_push{/if}">
+<section id="dashtrends" class="panel widget">
 	<header class="panel-heading">
 		<i class="icon-bar-chart"></i> {l s='Dashboard' d='Modules.Dashtrends.Admin'}
 		<span class="panel-heading-action">


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR aims to remove an unused feature (live update) that has been removed from the core but make this module throw an exception because even though the feature is not used, it requires a smarty variable not available anymore.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Partially fixes PrestaShop/Prestashop#27028
| How to test?  | On PrestaShop develop:<br>1. Disable modules `Dashproducts` & `Dashactivity`<br>2. Comment the line https://github.com/PrestaShop/PrestaShop/blob/develop/classes/module/Module.php#L2185 (`'allow_push' => false, // required by dashboard modules`)<br>3. Install this module<br>4. No error should appear in the page Dashboard

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
