### PR TITLE
Remove usage of legacy precision

### DIFF
--- a/dashtrends.php
+++ b/dashtrends.php
@@ -73,7 +73,6 @@ class dashtrends extends Module
     {
         $this->context->smarty->assign([
             'currency' => $this->context->currency,
-            '_PS_PRICE_DISPLAY_PRECISION_' => _PS_PRICE_DISPLAY_PRECISION_,
         ]);
 
         return $this->display(__FILE__, 'dashboard_zone_two.tpl');

--- a/views/templates/hook/dashboard_zone_two.tpl
+++ b/views/templates/hook/dashboard_zone_two.tpl
@@ -26,7 +26,6 @@
 	var currency_format = {$currency->format|floatval};
 	var currency_sign = '{$currency->sign|@addcslashes:'\''}';
 	var currency_blank = {$currency->blank|intval};
-	var priceDisplayPrecision = {$_PS_PRICE_DISPLAY_PRECISION_|intval};
 </script>
 <div class="clearfix"></div>
 <section id="dashtrends" class="panel widget">

--- a/views/templates/hook/dashboard_zone_two.tpl
+++ b/views/templates/hook/dashboard_zone_two.tpl
@@ -26,6 +26,7 @@
 	var currency_format = {$currency->format|floatval};
 	var currency_sign = '{$currency->sign|@addcslashes:'\''}';
 	var currency_blank = {$currency->blank|intval};
+        var priceDisplayPrecision = 0;
 </script>
 <div class="clearfix"></div>
 <section id="dashtrends" class="panel widget">

--- a/views/templates/hook/dashboard_zone_two.tpl
+++ b/views/templates/hook/dashboard_zone_two.tpl
@@ -26,7 +26,7 @@
 	var currency_format = {$currency->format|floatval};
 	var currency_sign = '{$currency->sign|@addcslashes:'\''}';
 	var currency_blank = {$currency->blank|intval};
-        var priceDisplayPrecision = 0;
+	var priceDisplayPrecision = 0;
 </script>
 <div class="clearfix"></div>
 <section id="dashtrends" class="panel widget">


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This constant is no longer used and is the only native module that uses it. It's not used in the code at all. I put zero like there is in https://github.com/PrestaShop/dashgoals/blob/dev/views/templates/hook/dashboard_zone_two.tpl.
| Type?         | refacto
| BC breaks?    | yes
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Tests green.